### PR TITLE
Update SCL initialisation method to allow the creation with a specifi…

### DIFF
--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/SclService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/SclService.java
@@ -47,9 +47,9 @@ public class SclService {
 
     private SclService(){ throw new IllegalStateException("SclService class"); }
 
-    public static SclRootAdapter initScl(String hVersion, String hRevision) throws ScdException {
-        UUID hId = UUID.randomUUID();
-        return new SclRootAdapter(hId.toString(),hVersion,hRevision);
+    public static SclRootAdapter initScl(Optional<UUID> hId, String hVersion, String hRevision) throws ScdException {
+        UUID headerId = hId.orElseGet(UUID::randomUUID);
+        return new SclRootAdapter(headerId.toString(), hVersion, hRevision);
     }
 
     public static SclRootAdapter addHistoryItem(SCL scd, String who, String what, String why){

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/SclServiceTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/SclServiceTest.java
@@ -32,6 +32,7 @@ import org.lfenergy.compas.sct.commons.scl.ied.LN0Adapter;
 import org.lfenergy.compas.sct.commons.testhelpers.SclTestMarshaller;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -314,7 +315,15 @@ class SclServiceTest {
     @Test
     void testInitScl(){
         assertDoesNotThrow(
-                () -> SclService.initScl("hVersion","hRevision")
+                () -> SclService.initScl(Optional.empty(), "hVersion","hRevision")
+        );
+    }
+
+    @Test
+    void testInitScl_With_hId_shouldNotThrowError(){
+        UUID hid = UUID.randomUUID();
+        assertDoesNotThrow(
+                () -> SclService.initScl(Optional.of(hid),"hVersion","hRevision")
         );
     }
 
@@ -322,7 +331,7 @@ class SclServiceTest {
     void testUpdateHeader() {
 
         SclRootAdapter sclRootAdapter = assertDoesNotThrow(
-                () -> SclService.initScl("hVersion","hRevision")
+                () -> SclService.initScl(Optional.empty(),"hVersion","hRevision")
         );
         UUID hId = UUID.fromString(sclRootAdapter.getHeaderAdapter().getHeaderId());
         HeaderDTO headerDTO = DTO.createHeaderDTO(hId);


### PR DESCRIPTION
Update SCL initialisation method to allow the creation with a specific header.id, or a random one otherwise

Signed-off-by: SAINTIER FRANCOIS <francois.saintier@rte-france.com>