### PR TITLE
feat(#351): RSR-894 Update Compasflow and extref prebindings based on Lnode

### DIFF
--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2022 RTE FRANCE
+// SPDX-FileCopyrightText: 2023 RTE FRANCE
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package org.lfenergy.compas.sct.commons;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.lfenergy.compas.scl2007b4.model.*;
 import org.lfenergy.compas.sct.commons.api.ExtRefEditor;
 import org.lfenergy.compas.sct.commons.dto.*;
@@ -24,13 +25,13 @@ import org.lfenergy.compas.sct.commons.util.PrivateEnum;
 import org.lfenergy.compas.sct.commons.util.PrivateUtils;
 import org.lfenergy.compas.sct.commons.util.Utils;
 
+import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.*;
 import static org.lfenergy.compas.sct.commons.util.CommonConstants.*;
-import static org.lfenergy.compas.sct.commons.util.Utils.isExtRefFeedBySameControlBlock;
 
 @RequiredArgsConstructor
 public class ExtRefEditorService implements ExtRefEditor {
@@ -42,21 +43,9 @@ public class ExtRefEditorService implements ExtRefEditor {
             "6", "THT",
             "7", "THT"
     );
-    private final ExtRefService extRefService;
 
-    /**
-     * Remove ExtRef which are fed by same Control Block
-     *
-     * @return list ExtRefs without duplication
-     */
-    public static List<TExtRef> filterDuplicatedExtRefs(List<TExtRef> tExtRefs) {
-        List<TExtRef> filteredList = new ArrayList<>();
-        tExtRefs.forEach(tExtRef -> {
-            if (filteredList.stream().noneMatch(t -> isExtRefFeedBySameControlBlock(tExtRef, t)))
-                filteredList.add(tExtRef);
-        });
-        return filteredList;
-    }
+    private final LdeviceService ldeviceService;
+    private final ExtRefService extRefService;
 
     /**
      * Provides valid IED sources according to EPF configuration.<br/>
@@ -425,8 +414,7 @@ public class ExtRefEditorService implements ExtRefEditor {
                         .flatMap(ldeviceService::getLdevices)
                         .forEach(tlDevice -> {
                             String flowSource = voltageCodification.get(tVoltageLevelName);
-                            TInputs tInputs = tlDevice.getLN0().getInputs();
-                            PrivateUtils.getPrivateStream(tInputs.getPrivate(), TCompasFlow.class)
+                            extRefService.getCompasFlows(tlDevice)
                                     .filter(TCompasFlow::isSetFlowSourceVoltageLevel)
                                     .filter(TCompasFlow::isSetExtRefiedName)
                                     .forEach(tCompasFlow -> {
@@ -435,19 +423,66 @@ public class ExtRefEditorService implements ExtRefEditor {
                                             extRefService.clearCompasFlowBinding(tCompasFlow);
                                         } else if (!tCompasFlow.getFlowSourceVoltageLevel().equals(flowSource)) {
                                             //debind extRef
-                                            extRefService.getMatchingExtRef(tInputs, tCompasFlow)
+                                            extRefService.getMatchingExtRefs(tlDevice, tCompasFlow)
                                                     .forEach(extRefService::clearExtRefBinding);
                                             //debind compas flow
                                             extRefService.clearCompasFlowBinding(tCompasFlow);
-
                                         }
                                     });
                         })
                 );
     }
 
-    private record DoNameAndDaName(String doName, String daName) {
+
+    @Override
+    public void updateIedNameBasedOnLnode(SCL scl) {
+        Map<TopoKey, TBay> bayByTopoKey = scl.getSubstation().stream()
+                .flatMap(tSubstation -> tSubstation.getVoltageLevel().stream())
+                .flatMap(tVoltageLevel -> tVoltageLevel.getBay().stream())
+                .map(tBay -> PrivateUtils.extractCompasPrivate(tBay, TCompasTopo.class)
+                        .filter(tCompasTopo -> isNotBlank(tCompasTopo.getNode()) && Objects.nonNull(tCompasTopo.getNodeOrder()))
+                        .map(tCompasTopo -> new BayTopoKey(tBay, new TopoKey(tCompasTopo.getNode(), tCompasTopo.getNodeOrder())))
+                )
+                .flatMap(Optional::stream)
+                .collect(Collectors.toMap(BayTopoKey::topoKey, BayTopoKey::bay));
+
+        scl.getIED().stream()
+                .flatMap(ldeviceService::getLdevices)
+                .forEach(tlDevice ->
+                        extRefService.getCompasFlows(tlDevice)
+                                .filter(tCompasFlow -> Objects.nonNull(tCompasFlow.getFlowSourceBayNode()) && Objects.nonNull(tCompasFlow.getFlowSourceBayNodeOrder()))
+                                .forEach(tCompasFlow ->
+                                        Optional.ofNullable(bayByTopoKey.get(new TopoKey(tCompasFlow.getFlowSourceBayNode().toString(), tCompasFlow.getFlowSourceBayNodeOrder())))
+                                                .flatMap(tBay -> tBay.getFunction().stream()
+                                                        .flatMap(tFunction -> tFunction.getLNode().stream())
+                                                        .filter(tlNode -> Objects.equals(tlNode.getLdInst(), tCompasFlow.getExtRefldinst())
+                                                                && Objects.equals(tlNode.getLnInst(), tCompasFlow.getExtReflnInst())
+                                                                && Utils.lnClassEquals(tlNode.getLnClass(), tCompasFlow.getExtReflnClass())
+                                                                && Objects.equals(tlNode.getPrefix(), tCompasFlow.getExtRefprefix()))
+                                                        .map(TLNode::getIedName)
+                                                        .filter(StringUtils::isNotBlank)
+                                                        .findFirst()
+                                                )
+                                                .ifPresentOrElse(iedName -> {
+                                                            extRefService.getMatchingExtRefs(tlDevice, tCompasFlow).forEach(tExtRef -> tExtRef.setIedName(iedName));
+                                                            tCompasFlow.setExtRefiedName(iedName);
+                                                        },
+                                                        () -> {
+                                                            extRefService.getMatchingExtRefs(tlDevice, tCompasFlow).forEach(extRefService::clearExtRefBinding);
+                                                            extRefService.clearCompasFlowBinding(tCompasFlow);
+                                                        }
+                                                )
+                                )
+                );
     }
 
+    record TopoKey(String FlowNode, BigInteger FlowNodeOrder) {
+    }
+
+    record BayTopoKey(TBay bay, TopoKey topoKey) {
+    }
+
+    private record DoNameAndDaName(String doName, String daName) {
+    }
 
 }

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/api/ExtRefEditor.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/api/ExtRefEditor.java
@@ -70,4 +70,9 @@ public interface ExtRefEditor {
      */
     void debindCompasFlowsAndExtRefsBasedOnVoltageLevel(SCL scd);
 
+    /**
+     * Update compas:Flow.ExtRefiedName and ExtRef.iedName, based on Substation LNode iedName
+     */
+    void updateIedNameBasedOnLnode(SCL scd);
+
 }

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/AccessPointAdapter.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/AccessPointAdapter.java
@@ -9,6 +9,7 @@ package org.lfenergy.compas.sct.commons.scl.ied;
 import org.lfenergy.compas.scl2007b4.model.*;
 import org.lfenergy.compas.sct.commons.dto.SclReportItem;
 import org.lfenergy.compas.sct.commons.exception.ScdException;
+import org.lfenergy.compas.sct.commons.scl.ExtRefService;
 import org.lfenergy.compas.sct.commons.scl.SclElementAdapter;
 import org.lfenergy.compas.sct.commons.scl.ldevice.LDeviceAdapter;
 import org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter;
@@ -18,8 +19,6 @@ import org.lfenergy.compas.sct.commons.util.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.lfenergy.compas.sct.commons.ExtRefEditorService.filterDuplicatedExtRefs;
 
 /**
  * A representation of the model object
@@ -245,7 +244,7 @@ public class AccessPointAdapter extends SclElementAdapter<IEDAdapter, TAccessPoi
                     return extRefs;
                 }).flatMap(Collection::stream)
                 .toList();
-        return new ExtRefAnalyzeRecord(sclReportItems, filterDuplicatedExtRefs(tExtRefList));
+        return new ExtRefAnalyzeRecord(sclReportItems, new ExtRefService().filterDuplicatedExtRefs(tExtRefList));
     }
 
     /**

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapter.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapter.java
@@ -8,7 +8,6 @@ package org.lfenergy.compas.sct.commons.scl.ied;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.lfenergy.compas.scl2007b4.model.*;
-import org.lfenergy.compas.sct.commons.ExtRefEditorService;
 import org.lfenergy.compas.sct.commons.dto.DataAttributeRef;
 import org.lfenergy.compas.sct.commons.dto.FcdaForDataSetsCreation;
 import org.lfenergy.compas.sct.commons.dto.SclReportItem;
@@ -104,13 +103,13 @@ public class InputsAdapter extends SclElementAdapter<LN0Adapter, TInputs> {
         try {
             ActiveStatus lDeviceStatus = ActiveStatus.fromValue(optionalLDeviceStatus.get());
             return switch (lDeviceStatus) {
-                case ON -> extRefService.getExtRefs(currentElem)
+                case ON -> currentElem.getExtRef().stream()
                         .filter(tExtRef -> StringUtils.isNotBlank(tExtRef.getIedName()) && StringUtils.isNotBlank(tExtRef.getDesc()))
                         .map(extRef -> updateExtRefIedName(extRef, icdSystemVersionToIed.get(extRef.getIedName())))
                         .flatMap(Optional::stream)
                         .toList();
                 case OFF -> {
-                    extRefService.getExtRefs(currentElem).forEach(extRefService::clearExtRefBinding);
+                    currentElem.getExtRef().forEach(extRefService::clearExtRefBinding);
                     yield Collections.emptyList();
                 }
             };
@@ -209,7 +208,7 @@ public class InputsAdapter extends SclElementAdapter<LN0Adapter, TInputs> {
         if (StringUtils.isBlank(currentBayUuid)) {
             return List.of(getIedAdapter().buildFatalReportItem(MESSAGE_IED_MISSING_COMPAS_BAY_UUID));
         }
-        return extRefService.getExtRefs(currentElem)
+        return currentElem.getExtRef().stream()
                 .filter(this::areBindingAttributesPresent)
                 .filter(this::isExternalBound)
                 .filter(this::matchingCompasFlowIsActiveOrUntested)
@@ -374,7 +373,7 @@ public class InputsAdapter extends SclElementAdapter<LN0Adapter, TInputs> {
      * @return list ExtRefs without duplication
      */
     public List<TExtRef> filterDuplicatedExtRefs() {
-        return ExtRefEditorService.filterDuplicatedExtRefs(extRefService.getExtRefs(currentElem).toList());
+      return new ExtRefService().filterDuplicatedExtRefs(currentElem.getExtRef());
     }
 
 }

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/util/Utils.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/util/Utils.java
@@ -10,12 +10,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.util.JAXBSource;
 import org.apache.commons.lang3.StringUtils;
-import org.lfenergy.compas.scl2007b4.model.TExtRef;
-import org.lfenergy.compas.scl2007b4.model.TLLN0Enum;
 import org.lfenergy.compas.sct.commons.exception.ScdException;
-import org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter;
-import org.lfenergy.compas.sct.commons.scl.ied.IEDAdapter;
-import org.lfenergy.compas.sct.commons.scl.ldevice.LDeviceAdapter;
 
 import javax.xml.namespace.QName;
 import java.util.*;
@@ -369,25 +364,6 @@ public final class Utils {
         } catch (JAXBException e) {
             throw new ScdException(e.getMessage(), e);
         }
-    }
-
-    /**
-     * Checks if two ExtRefs fed by same Control Block
-     *
-     * @param t1 extref to compare
-     * @param t2 extref to compare
-     * @return true if the two ExtRef are fed by same Control Block, otherwise false
-     */
-    public static boolean isExtRefFeedBySameControlBlock(TExtRef t1, TExtRef t2) {
-        String srcLNClass1 = (t1.isSetSrcLNClass()) ? t1.getSrcLNClass().get(0) : TLLN0Enum.LLN_0.value();
-        String srcLNClass2 = (t2.isSetSrcLNClass()) ? t2.getSrcLNClass().get(0) : TLLN0Enum.LLN_0.value();
-        return Utils.equalsOrBothBlank(t1.getIedName(), t2.getIedName())
-                && Utils.equalsOrBothBlank(t1.getSrcLDInst(), t2.getSrcLDInst())
-                && srcLNClass1.equals(srcLNClass2)
-                && Utils.equalsOrBothBlank(t1.getSrcLNInst(), t2.getSrcLNInst())
-                && Utils.equalsOrBothBlank(t1.getSrcPrefix(), t2.getSrcPrefix())
-                && Utils.equalsOrBothBlank(t1.getSrcCBName(), t2.getSrcCBName())
-                && Objects.equals(t1.getServiceType(), t2.getServiceType());
     }
 
 }

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/testhelpers/SclHelper.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/testhelpers/SclHelper.java
@@ -13,6 +13,7 @@ import org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter;
 import org.lfenergy.compas.sct.commons.scl.ln.LN0Adapter;
 import org.lfenergy.compas.sct.commons.scl.ln.LNAdapter;
 import org.lfenergy.compas.sct.commons.util.ControlBlockEnum;
+import org.lfenergy.compas.sct.commons.util.PrivateUtils;
 import org.lfenergy.compas.sct.commons.util.Utils;
 import org.opentest4j.AssertionFailedError;
 
@@ -69,7 +70,14 @@ public final class SclHelper {
                 .stream()
                 .filter(extRef -> extRefDesc.equals(extRef.getDesc()))
                 .findFirst()
-                .orElseThrow(() -> new AssertionFailedError(String.format("ExtRef.des=%s not found in IED.name=%s,LDevice.inst=%s", extRefDesc, iedName, ldInst)));
+                .orElseThrow(() -> new AssertionFailedError(String.format("ExtRef.desc=%s not found in IED.name=%s,LDevice.inst=%s", extRefDesc, iedName, ldInst)));
+    }
+
+    public static TCompasFlow findCompasFlow(SCL scl, String iedName, String ldInst, String compasFlowDataStreamKey) {
+        return PrivateUtils.extractCompasPrivates(findInputs(scl, iedName, ldInst).getCurrentElem(), TCompasFlow.class)
+                .filter(compasFlow -> compasFlowDataStreamKey.equals(compasFlow.getDataStreamKey()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionFailedError(String.format("CompasFlow.dataStreamKey=%s not found in IED.name=%s,LDevice.inst=%s", compasFlowDataStreamKey, iedName, ldInst)));
     }
 
     public static LN0Adapter findLn0(SCL scl, String iedName, String ldInst) {

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/util/UtilsTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/util/UtilsTest.java
@@ -11,10 +11,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.support.ReflectionSupport;
-import org.lfenergy.compas.scl2007b4.model.TExtRef;
 import org.lfenergy.compas.scl2007b4.model.TLLN0Enum;
 import org.lfenergy.compas.scl2007b4.model.TLN;
-import org.lfenergy.compas.scl2007b4.model.TServiceType;
 import org.lfenergy.compas.sct.commons.dto.FCDAInfo;
 import org.lfenergy.compas.sct.commons.exception.ScdException;
 
@@ -22,7 +20,6 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.lfenergy.compas.sct.commons.testhelpers.SclHelper.createExtRefExample;
 import static org.lfenergy.compas.sct.commons.util.Utils.copySclElement;
 
 
@@ -512,57 +509,6 @@ class UtilsTest {
         String result = Utils.toHex(number, length);
         // Then
         assertThat(result).isEqualTo(expected);
-    }
-
-    @Test
-    void isExtRefFeedBySameControlBlock_should_return_true() {
-        // Given
-        TExtRef tExtRefLnClass = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefLnClass.getSrcLNClass().add(TLLN0Enum.LLN_0.value());
-        TExtRef tExtRef = createExtRefExample("CB_1", TServiceType.GOOSE);
-        // When
-        // Then
-        assertThat(Utils.isExtRefFeedBySameControlBlock(tExtRef, tExtRefLnClass)).isTrue();
-        assertThat(Utils.isExtRefFeedBySameControlBlock(createExtRefExample("CB_1", TServiceType.GOOSE), tExtRef)).isTrue();
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("provideExtRefsToCompare")
-    void isExtRefFeedBySameControlBlock_should_return_false(String testCase, TExtRef tExtRef1, TExtRef tExtRef2) {
-        // Given
-        // When
-        // Then
-        assertThat(Utils.isExtRefFeedBySameControlBlock(tExtRef1, tExtRef2)).isFalse();
-    }
-
-    private static Stream<Arguments> provideExtRefsToCompare() {
-        TExtRef tExtRefLnClass = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefLnClass.getSrcLNClass().add("XXX");
-        TExtRef tExtRefIedName = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefIedName.setIedName("IED_XXX");
-        TExtRef tExtRefLdInst = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefLdInst.setSrcLDInst("LD_XXX");
-        TExtRef tExtRefLnInst = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefLnInst.setSrcLNInst("X");
-        TExtRef tExtRefPrefix = createExtRefExample("CB_1", TServiceType.GOOSE);
-        tExtRefPrefix.setSrcPrefix("X");
-
-        return Stream.of(
-                Arguments.of("ExtRef is not fed by same CB when different ServiceType", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        createExtRefExample("CB_1", TServiceType.SMV)),
-                Arguments.of("ExtRef is not fed by same CB when different SrcCBName", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        createExtRefExample("CB_2", TServiceType.GOOSE)),
-                Arguments.of("ExtRef is not fed by same CB when different SrcLnClass", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        tExtRefLnClass),
-                Arguments.of("ExtRef is not fed by same CB when different IedName", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        tExtRefIedName),
-                Arguments.of("ExtRef is not fed by same CB when different SrcLdInst", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        tExtRefLdInst),
-                Arguments.of("ExtRef is not fed by same CB when different SrcLnInst", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        tExtRefLnInst),
-                Arguments.of("ExtRef is not fed by same CB when different SrcPrefix", createExtRefExample("CB_1", TServiceType.GOOSE),
-                        tExtRefPrefix)
-        );
     }
 
     @Test

--- a/sct-commons/src/test/resources/scd-extref-iedname/scd_set_extref_iedname_based_on_lnode_success.xml
+++ b/sct-commons/src/test/resources/scd-extref-iedname/scd_set_extref_iedname_based_on_lnode_success.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
+    <Header id="hId" version="2007" revision="B" toolID="COMPAS"/>
+    <Substation name="SITE">
+        <VoltageLevel nomFreq="50" numPhases="3" name="0">
+            <Voltage unit="V" multiplier="k">0</Voltage>
+            <Bay name="BAY_1">
+                <Private type="COMPAS-Topo">
+                    <compas:Topo Node="101" NodeOrder="2" Direction="Down"/>
+                </Private>
+                <Private type="COMPAS-Bay">
+                    <compas:Bay BayCodif="TG00000001" UUID="9cd6f05b-1bbd-4ba3-86c5-41c99103e06d" Version="1"
+                                MainShortLabel="SITE1" SecondLabel="SITE-TGENE" NumBay="7" BayCount="1"/>
+                </Private>
+                <Function name="FUNCTION_1">
+                    <Private type="COMPAS-Function">
+                        <compas:Function UUID="8f4cda3f-828c-4006-9b87-2af96b19304b" Label="FUNCTION_1"/>
+                    </Private>
+                    <LNode iedName="IED_NAME2" ldInst="LD_INST21" lnClass="ANCR" lnInst="1"/>
+                </Function>
+            </Bay>
+        </VoltageLevel>
+    </Substation>
+    <IED name="IED_NAME1">
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader ICDSystemVersionUUID="System_Version_IED_NAME1" IEDType="BCU" IEDSubstationinstance="11" IEDSystemVersioninstance="1" IEDName="IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" IEDredundancy="A" BayLabel="3THEIX2" hwRev="0.0.2." swRev="1.0a"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU" headerVersion="1.2a" headerRevision="412995"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LD_INST11" ldName="IED_NAME1LD_INST11">
+                    <LN0 lnClass="LLN0" inst="" lnType="LNEX1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <Private type="COMPAS-Flow">
+                                <compas:Flow FlowSourceBayNode="101" FlowSourceBayNodeOrder="2" dataStreamKey="STAT_LDSUIED_LPDO 1 Sortie_13_BOOLEAN_18_stVal_1" ExtRefiedName="IED_NAME_A_CHANGER" ExtRefldinst="LD_INST21" ExtRefprefix="" ExtReflnClass="ANCR" ExtReflnInst="1" FlowID="1" FlowStatus="ACTIVE" FlowKind="BAY_INTERNAL"/>
+                            </Private>
+                            <ExtRef iedName="IED_NAME_A_CHANGER" ldInst="LD_INST21" lnClass="ANCR" lnInst="1" doName="DoName1" daName="daName1" intAddr="INT_ADDR11" pDO="Do11.sdo11" pDA="da11.bda111.bda112.bda113" desc="STAT_LDSUIED_LPDO 1 Sortie_13_BOOLEAN_18_stVal_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME2">
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader ICDSystemVersionUUID="System_Version_IED_NAME2" IEDType="BCU" IEDSubstationinstance="22" IEDSystemVersioninstance="1" IEDName="IED_NAME2" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" IEDredundancy="A" BayLabel="3THEIX2" hwRev="0.0.2." swRev="1.0a"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU" headerVersion="1.2a" headerRevision="412995"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LD_INST21">
+                    <LN0 lnClass="LLN0" inst="" lnType="LNEX1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="ANCR" inst="1" lnType="lnType"/>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <DataTypeTemplates>
+        <LNodeType lnClass="LLN0" id="LNEX1">
+            <DO name="Mod" type="DO1"/>
+        </LNodeType>
+        <LNodeType lnClass="ANCR" id="lnType">
+            <DO name="DoName1" type="DO2"/>
+        </LNodeType>
+        <DOType cdc="ENC" id="DO1">
+            <DA fc="ST" name="stVal" bType="Enum" type="BehaviourModeKind"/>
+        </DOType>
+        <DOType cdc="ENC" id="DO2">
+            <DA fc="BL" name="daName1" bType="BOOLEAN"/>
+        </DOType>
+        <EnumType id="BehaviourModeKind">
+            <EnumVal ord="1">on</EnumVal>
+            <EnumVal ord="2">off</EnumVal>
+            <EnumVal ord="3">test</EnumVal>
+        </EnumType>
+    </DataTypeTemplates>
+</SCL>


### PR DESCRIPTION
I renamed **ExtRefService** to **ExtRefEditorService** in order to use **ExtRefService** name for the new Scl element Service architecture.