### PR TITLE
feat(#378): remove validation when DOI(Mod) and DAI(stVal) does not exists

### DIFF
--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesService.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 RTE FRANCE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfenergy.compas.sct.commons;
+
+import org.lfenergy.compas.scl2007b4.model.*;
+
+import static org.lfenergy.compas.sct.commons.util.CommonConstants.MOD_DO_NAME;
+import static org.lfenergy.compas.sct.commons.util.CommonConstants.STVAL_DA_NAME;
+
+public class DataTypeTemplatesService {
+
+    final LnodeTypeService lnodeTypeService = new LnodeTypeService();
+    final DoTypeService doTypeService = new DoTypeService();
+    final DoService doService = new DoService();
+
+    /**
+     * verify if DO(name=Mod)/DA(name=stVal) exists in DataTypeTemplate
+     * @param dtt TDataTypeTemplates where Data object and Data attribute exists
+     * @param lNodeTypeId LNode Type ID where Data object exists
+     *  DataTypeTemplates model :
+     * <DataTypeTemplates>
+     *     <LNodeType lnClass="LNodeTypeClass" id="LNodeTypeID">
+     *         <DO name="Mod" type="DOModTypeID" ../>
+     *     </LNodeType>
+     *     ...
+     *     <DOType cdc="DOTypeCDC" id="DOModTypeID">
+     *         <DA name="stVal" ../>
+     *     </DOType>
+     * </DataTypeTemplates>
+     * @return true if the Data Object (Mod) and Data attribute (stVal) present, false otherwise
+     */
+    public boolean isDoModAndDaStValExist(TDataTypeTemplates dtt, String lNodeTypeId) {
+        return lnodeTypeService.findLnodeType(dtt, lNodeType -> lNodeType.getId().equals(lNodeTypeId))
+                .map(lNodeType -> doService.findDo(lNodeType, tdo -> tdo.getName().equals(MOD_DO_NAME))
+                        .map(tdo -> doTypeService.findDoType(dtt, doType -> doType.getId().equals(tdo.getType()))
+                                .map(doType -> doType.getSDOOrDA().stream()
+                                                .filter(unNaming -> unNaming.getClass().equals(TDA.class))
+                                                .map(TDA.class::cast)
+                                                .anyMatch(tda -> tda.getName().equals(STVAL_DA_NAME)))
+                                 .orElse(false))
+                         .orElse(false))
+                 .orElse(false);
+    }
+}

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesService.java
@@ -32,13 +32,13 @@ public class DataTypeTemplatesService {
      * @return true if the Data Object (Mod) and Data attribute (stVal) present, false otherwise
      */
     public boolean isDoModAndDaStValExist(TDataTypeTemplates dtt, String lNodeTypeId) {
-        return lnodeTypeService.findLnodeType(dtt, lNodeType -> lNodeType.getId().equals(lNodeTypeId))
-                .map(lNodeType -> doService.findDo(lNodeType, tdo -> tdo.getName().equals(MOD_DO_NAME))
-                        .map(tdo -> doTypeService.findDoType(dtt, doType -> doType.getId().equals(tdo.getType()))
+        return lnodeTypeService.findLnodeType(dtt, lNodeType -> lNodeTypeId.equals(lNodeType.getId()))
+                .map(lNodeType -> doService.findDo(lNodeType, tdo -> MOD_DO_NAME.equals(tdo.getName()))
+                        .map(tdo -> doTypeService.findDoType(dtt, doType -> tdo.getType().equals(doType.getId()))
                                 .map(doType -> doType.getSDOOrDA().stream()
-                                                .filter(unNaming -> unNaming.getClass().equals(TDA.class))
+                                                .filter(sdoOrDa -> sdoOrDa.getClass().equals(TDA.class))
                                                 .map(TDA.class::cast)
-                                                .anyMatch(tda -> tda.getName().equals(STVAL_DA_NAME)))
+                                                .anyMatch(tda -> STVAL_DA_NAME.equals(tda.getName())))
                                  .orElse(false))
                          .orElse(false))
                  .orElse(false);

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
@@ -44,6 +44,7 @@ public class ExtRefEditorService implements ExtRefEditor {
             "7", "THT"
     );
 
+    private final IedService iedService;
     private final LdeviceService ldeviceService;
     private final ExtRefService extRefService;
     private final DataTypeTemplatesService dataTypeTemplatesService;
@@ -87,25 +88,25 @@ public class ExtRefEditorService implements ExtRefEditor {
      * @param sclReportItems List of SclReportItem
      * @return list of ExtRef and associated Bay
      */
-    private List<ExtRefInfo.ExtRefWithBayReference> getExtRefWithBayReferenceInLDEPF(final LDeviceAdapter lDeviceAdapter, final List<SclReportItem> sclReportItems) {
+    private List<ExtRefInfo.ExtRefWithBayReference> getExtRefWithBayReferenceInLDEPF(TDataTypeTemplates dataTypeTemplates, TIED tied, final TLDevice tlDevice, final List<SclReportItem> sclReportItems) {
         List<ExtRefInfo.ExtRefWithBayReference> extRefBayReferenceList = new ArrayList<>();
-        IEDAdapter iedAdapter = lDeviceAdapter.getParentAdapter();
-        if (iedAdapter.getPrivateCompasBay().isEmpty()) {
-            sclReportItems.add(SclReportItem.error(lDeviceAdapter.getXPath(), "The IED has no Private Bay"));
-            if (iedAdapter.getCompasICDHeader().isEmpty()) {
-                sclReportItems.add(SclReportItem.error(lDeviceAdapter.getXPath(), "The IED has no Private compas:ICDHeader"));
+        String lDevicePath = "SCL/IED[@name=\""+ tied.getName() + "\"]/AccessPoint/Server/LDevice[@inst=\"" + tlDevice.getInst() + "\"]";
+        Optional<TCompasBay> tCompasBay = PrivateUtils.extractCompasPrivate(tied, TCompasBay.class);
+        if (tCompasBay.isEmpty()) {
+            sclReportItems.add(SclReportItem.error(lDevicePath, "The IED has no Private Bay"));
+            if (PrivateUtils.extractCompasPrivate(tied, TCompasICDHeader.class).isEmpty()) {
+                sclReportItems.add(SclReportItem.error(lDevicePath, "The IED has no Private compas:ICDHeader"));
             }
             return Collections.emptyList();
         }
 
-        if(dataTypeTemplatesService.isDoModAndDaStValExist(iedAdapter.getParentAdapter().getDataTypeTemplateAdapter().getCurrentElem(),
-                lDeviceAdapter.getLN0Adapter().getLnType())) {
-            extRefBayReferenceList.addAll(lDeviceAdapter.getLN0Adapter()
-                    .getInputsAdapter().getCurrentElem()
+        if (dataTypeTemplatesService.isDoModAndDaStValExist(dataTypeTemplates, tlDevice.getLN0().getLnType())) {
+            extRefBayReferenceList.addAll(tlDevice.getLN0()
+                    .getInputs()
                     .getExtRef().stream()
-                    .map(extRef -> new ExtRefInfo.ExtRefWithBayReference(iedAdapter.getName(), iedAdapter.getPrivateCompasBay().get(), extRef)).toList());
+                    .map(extRef -> new ExtRefInfo.ExtRefWithBayReference(tied.getName(), tCompasBay.get(), extRef)).toList());
         } else {
-            sclReportItems.add(SclReportItem.error(lDeviceAdapter.getXPath(), "DO@name=Mod/DA@name=stVal not found in DataTypeTemplate"));
+            sclReportItems.add(SclReportItem.error(lDevicePath, "DO@name=Mod/DA@name=stVal not found in DataTypeTemplate"));
         }
         return extRefBayReferenceList;
     }
@@ -298,29 +299,27 @@ public class ExtRefEditorService implements ExtRefEditor {
     @Override
     public List<SclReportItem> manageBindingForLDEPF(SCL scd, EPF epf) {
         List<SclReportItem> sclReportItems = new ArrayList<>();
-        if (!epf.isSetChannels()) return sclReportItems;
         SclRootAdapter sclRootAdapter = new SclRootAdapter(scd);
-        sclRootAdapter.streamIEDAdapters()
-                .filter(iedAdapter -> !iedAdapter.getName().contains("TEST"))
-                .map(iedAdapter -> iedAdapter.findLDeviceAdapterByLdInst(LDEVICE_LDEPF))
-                .flatMap(Optional::stream)
-                .forEach(lDeviceAdapter -> getExtRefWithBayReferenceInLDEPF(lDeviceAdapter, sclReportItems)
-                        .forEach(extRefBayRef -> epf.getChannels().getChannel().stream().filter(tChannel -> doesExtRefMatchLDEPFChannel(extRefBayRef.extRef(), tChannel))
-                                .findFirst().ifPresent(channel -> {
-                                    List<TIED> iedSources = getIedSources(sclRootAdapter, extRefBayRef.compasBay(), channel);
-                                    if (iedSources.size() == 1) {
-                                        updateLDEPFExtRefBinding(extRefBayRef.extRef(), iedSources.get(0), channel);
-                                        sclReportItems.addAll(updateLDEPFDos(lDeviceAdapter, extRefBayRef.extRef(), channel));
-                                    } else {
-                                        if (iedSources.size() > 1) {
-                                            sclReportItems.add(SclReportItem.warning(null, "There is more than one IED source to bind the signal " +
-                                                    "/IED@name=" + extRefBayRef.iedName() + "/LDevice@inst=LDEPF/LN0" +
-                                                    "/ExtRef@desc=" + extRefBayRef.extRef().getDesc()));
-                                        }
-                                        // If the source IED is not found, there will be no update or report message.
-                                    }
-                                }))
-                );
+        if (!epf.isSetChannels()) return sclReportItems;
+        iedService.getFilteredIeds(scd, ied -> !ied.getName().contains("TEST"))
+                .forEach(tied -> ldeviceService.findLdevice(tied, tlDevice -> LDEVICE_LDEPF.equals(tlDevice.getInst()))
+                        .ifPresent(tlDevice -> getExtRefWithBayReferenceInLDEPF(scd.getDataTypeTemplates(), tied, tlDevice, sclReportItems)
+                                .forEach(extRefBayRef -> epf.getChannels().getChannel().stream().filter(tChannel -> doesExtRefMatchLDEPFChannel(extRefBayRef.extRef(), tChannel))
+                                        .findFirst().ifPresent(channel -> {
+                                            List<TIED> iedSources = getIedSources(sclRootAdapter, extRefBayRef.compasBay(), channel);
+                                            if (iedSources.size() == 1) {
+                                                updateLDEPFExtRefBinding(extRefBayRef.extRef(), iedSources.get(0), channel);
+                                                LDeviceAdapter lDeviceAdapter = new LDeviceAdapter(new IEDAdapter(sclRootAdapter, tied.getName()), tlDevice);
+                                                sclReportItems.addAll(updateLDEPFDos(lDeviceAdapter, extRefBayRef.extRef(), channel));
+                                            } else {
+                                                if (iedSources.size() > 1) {
+                                                    sclReportItems.add(SclReportItem.warning(null, "There is more than one IED source to bind the signal " +
+                                                            "/IED@name=" + extRefBayRef.iedName() + "/LDevice@inst=LDEPF/LN0" +
+                                                            "/ExtRef@desc=" + extRefBayRef.extRef().getDesc()));
+                                                }
+                                                // If the source IED is not found, there will be no update or report message.
+                                            }
+                                        }))));
         return sclReportItems;
     }
 
@@ -436,7 +435,6 @@ public class ExtRefEditorService implements ExtRefEditor {
 
     @Override
     public void debindCompasFlowsAndExtRefsBasedOnVoltageLevel(SCL scd) {
-        LdeviceService ldeviceService = new LdeviceService();
         scd.getSubstation()
                 .stream()
                 .flatMap(tSubstation -> tSubstation.getVoltageLevel().stream())

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/dto/ExtRefInfo.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/dto/ExtRefInfo.java
@@ -99,6 +99,6 @@ public class ExtRefInfo extends LNodeMetaDataEmbedder{
      * @param compasBay The Bay object
      * @param extRef The ExtRef object
      */
-    public record ExtRefBayReference(String iedName, TCompasBay compasBay, TExtRef extRef){ }
+    public record ExtRefWithBayReference(String iedName, TCompasBay compasBay, TExtRef extRef){ }
 
 }

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapter.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapter.java
@@ -50,7 +50,6 @@ public class InputsAdapter extends SclElementAdapter<LN0Adapter, TInputs> {
     private static final String MESSAGE_INVALID_SERVICE_TYPE = "The signal ExtRef ServiceType attribute is unexpected : %s";
     private static final String MESSAGE_IED_MISSING_COMPAS_BAY_UUID = "IED is missing Private/compas:Bay@UUID attribute";
     private static final String MESSAGE_EXTREF_DESC_MALFORMED = "ExtRef.serviceType=Report but ExtRef.desc attribute is malformed";
-    private static final String MESSAGE_LDEVICE_STATUS_UNDEFINED = "The LDevice status is undefined";
     private static final String MESSAGE_EXTREF_IEDNAME_DOES_NOT_MATCH_ANY_SYSTEM_VERSION_UUID = "The signal ExtRef iedName does not match any " +
             "IED/Private/compas:ICDHeader@ICDSystemVersionUUID";
     private static final String MESSAGE_SOURCE_LDEVICE_STATUS_UNDEFINED = "The signal ExtRef source LDevice %s status is undefined";
@@ -98,7 +97,7 @@ public class InputsAdapter extends SclElementAdapter<LN0Adapter, TInputs> {
     public List<SclReportItem> updateAllExtRefIedNames(Map<String, IEDAdapter> icdSystemVersionToIed) {
         Optional<String> optionalLDeviceStatus = getLDeviceAdapter().getLDeviceStatus();
         if (optionalLDeviceStatus.isEmpty()) {
-            return List.of(getLDeviceAdapter().buildFatalReportItem(MESSAGE_LDEVICE_STATUS_UNDEFINED));
+            optionalLDeviceStatus = Optional.of(ActiveStatus.ON.getValue());
         }
         try {
             ActiveStatus lDeviceStatus = ActiveStatus.fromValue(optionalLDeviceStatus.get());

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ldevice/LDeviceAdapter.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/scl/ldevice/LDeviceAdapter.java
@@ -27,8 +27,6 @@ import org.lfenergy.compas.sct.commons.util.Utils;
 
 import java.util.*;
 
-import static org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter.MOD_DO_TYPE_NAME;
-import static org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter.STVAL_DA_TYPE_NAME;
 import static org.lfenergy.compas.sct.commons.util.CommonConstants.*;
 import static org.lfenergy.compas.sct.commons.util.Utils.copySclElement;
 
@@ -487,33 +485,6 @@ public class LDeviceAdapter extends SclElementAdapter<IEDAdapter, TLDevice> {
                 .getLDeviceAdapterByLdInst(tExtRef.getSrcLDInst()).getLdName();
         String lnClass = !tExtRef.isSetSrcLNClass() ? TLLN0Enum.LLN_0.value() : tExtRef.getSrcLNClass().get(0);
         return sourceLdName + "/" + lnClass + "." + tExtRef.getSrcCBName();
-    }
-
-    /**
-     * Provides a list of ExtRef and associated Bay <br/>
-     * - The location of ExtRef should be in an active LDevice (inst=LDEPF) <br/>
-     * - ExtRef that lacks Bay or ICDHeader Private is not returned <br/>
-     *
-     * @param sclReportItems List of SclReportItem
-     * @return list of ExtRef and associated Bay
-     */
-    public List<ExtRefInfo.ExtRefBayReference> getExtRefBayReferenceForActifLDEPF(final List<SclReportItem> sclReportItems) {
-        List<ExtRefInfo.ExtRefBayReference> extRefBayReferenceList = new ArrayList<>();
-        IEDAdapter parentIedAdapter = getParentAdapter();
-        if (parentIedAdapter.getPrivateCompasBay().isEmpty()) {
-            sclReportItems.add(SclReportItem.error(getXPath(), "The IED has no Private Bay"));
-            if (parentIedAdapter.getCompasICDHeader().isEmpty()) {
-                sclReportItems.add(SclReportItem.error(getXPath(), "The IED has no Private compas:ICDHeader"));
-            }
-            return Collections.emptyList();
-        }
-
-        getLDeviceStatus().map(ActiveStatus::fromValue).ifPresentOrElse(s -> {
-            if (ActiveStatus.ON.equals(s)) {
-                extRefBayReferenceList.addAll(getLN0Adapter().getInputsAdapter().getCurrentElem().getExtRef().stream().map(extRef -> new ExtRefInfo.ExtRefBayReference(parentIedAdapter.getName(), parentIedAdapter.getPrivateCompasBay().get(), extRef)).toList());
-            }
-        }, () -> sclReportItems.add(SclReportItem.error(getXPath(), "There is no DOI@name=" + MOD_DO_TYPE_NAME + "/DAI@name=" + STVAL_DA_TYPE_NAME + "/Val for LDevice@inst" + LDEVICE_LDEPF)));
-        return extRefBayReferenceList;
     }
 
     private TFCDA toFCDA(TFCDAFilter tfcdaFilter) {

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesServiceTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/DataTypeTemplatesServiceTest.java
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2024 RTE FRANCE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfenergy.compas.sct.commons;
+
+import org.junit.jupiter.api.Test;
+import org.lfenergy.compas.scl2007b4.model.*;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DataTypeTemplatesServiceTest {
+
+    @Test
+    void isDoModAndDaStValExist_when_LNodeType_not_exist_should_return_false() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        scl.setDataTypeTemplates(dtt);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void isDoModAndDaStValExist_when_Do_not_exist_should_return_false() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        TLNodeType tlNodeType = new TLNodeType();
+        tlNodeType.setId("lnodeTypeId");
+        dtt.getLNodeType().add(tlNodeType);
+        scl.setDataTypeTemplates(dtt);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isDoModAndDaStValExist_when_DoType_not_exist_should_return_false() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        TLNodeType tlNodeType = new TLNodeType();
+        tlNodeType.setId("lnodeTypeId");
+        TDO tdo = new TDO();
+        tdo.setType("doTypeId");
+        tdo.setName("Mod");
+        tlNodeType.getDO().add(tdo);
+        dtt.getLNodeType().add(tlNodeType);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void isDoModAndDaStValExist_when_Da_Mod_not_exist_should_return_false() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        TLNodeType tlNodeType = new TLNodeType();
+        tlNodeType.setId("lnodeTypeId");
+        TDO tdo = new TDO();
+        tdo.setType("doTypeId");
+        tdo.setName("Mod");
+        tlNodeType.getDO().add(tdo);
+        dtt.getLNodeType().add(tlNodeType);
+        TDOType tdoType = new TDOType();
+        tdoType.setId("doTypeId");
+        dtt.getDOType().add(tdoType);
+        scl.setDataTypeTemplates(dtt);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void isDoModAndDaStValExist_when_Da_stVal_not_found_should_return_false() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        TLNodeType tlNodeType = new TLNodeType();
+        tlNodeType.setId("lnodeTypeId");
+        TDO tdo = new TDO();
+        tdo.setType("doTypeId");
+        tdo.setName("Mod");
+        tlNodeType.getDO().add(tdo);
+        dtt.getLNodeType().add(tlNodeType);
+        TDOType tdoType = new TDOType();
+        tdoType.setId("doTypeId");
+        TDA tda = new TDA();
+        tda.setName("daName");
+        tdoType.getSDOOrDA().add(tda);
+        dtt.getDOType().add(tdoType);
+        scl.setDataTypeTemplates(dtt);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void isDoModAndDaStValExist_when_DO_Mod_And_DA_stVal_exist_return_true() {
+        //Given
+        SCL scl = new SCL();
+        TDataTypeTemplates dtt = new TDataTypeTemplates();
+        TLNodeType tlNodeType = new TLNodeType();
+        tlNodeType.setId("lnodeTypeId");
+        TDO tdo = new TDO();
+        tdo.setType("doTypeId");
+        tdo.setName("Mod");
+        tlNodeType.getDO().add(tdo);
+        dtt.getLNodeType().add(tlNodeType);
+        TDOType tdoType = new TDOType();
+        tdoType.setId("doTypeId");
+        TDA tda = new TDA();
+        tda.setName("stVal");
+        tdoType.getSDOOrDA().add(tda);
+        dtt.getDOType().add(tdoType);
+        scl.setDataTypeTemplates(dtt);
+        //When
+        DataTypeTemplatesService dataTypeTemplatesService = new DataTypeTemplatesService();
+        boolean result = dataTypeTemplatesService.isDoModAndDaStValExist(dtt, "lnodeTypeId");
+        //Then
+        assertThat(result).isTrue();
+    }
+}

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/ExtRefEditorServiceTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/ExtRefEditorServiceTest.java
@@ -39,7 +39,7 @@ class ExtRefEditorServiceTest {
 
     @BeforeEach
     void init() {
-        extRefEditorService = new ExtRefEditorService(new LdeviceService(), new ExtRefService(), new DataTypeTemplatesService());
+        extRefEditorService = new ExtRefEditorService(new IedService(), new LdeviceService(), new ExtRefService(), new DataTypeTemplatesService());
     }
 
     @Test
@@ -500,7 +500,7 @@ class ExtRefEditorServiceTest {
     }
 
     @Test
-    void getExtRefBayReferenceForActifLDEPF_when_DOI_Mod_and_DAI_stVal_notExists_should_precede() {
+    void manageBindingForLDEPF_when_DOI_Mod_and_DAI_stVal_notExists_should_precede() {
         // Given
         SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_withoutModStValInLN0.xml");
         // When
@@ -582,7 +582,7 @@ class ExtRefEditorServiceTest {
     }
 
     @Test
-    void getExtRefBayReferenceForActifLDEPF_when_DO_Mod_and_DA_stVal_NotFoundInDataTypeTemplate_should_return_error() {
+    void manageBindingForLDEPF_when_DO_Mod_and_DA_stVal_NotFoundInDataTypeTemplate_should_return_error() {
         // Given
         SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_withoutModStValInDataTypeTemplate.xml");
         // When
@@ -595,11 +595,11 @@ class ExtRefEditorServiceTest {
                 .extracting(SclReportItem::message, SclReportItem::xpath)
                 .containsExactly(
                         Tuple.tuple("DO@name=Mod/DA@name=stVal not found in DataTypeTemplate",
-                         "/SCL/IED[@name=\"IED_NAME1\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]"),
+                         "SCL/IED[@name=\"IED_NAME1\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]"),
                         Tuple.tuple("DO@name=Mod/DA@name=stVal not found in DataTypeTemplate",
-                                "/SCL/IED[@name=\"IED_NAME2\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]"),
+                                "SCL/IED[@name=\"IED_NAME2\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]"),
                         Tuple.tuple("DO@name=Mod/DA@name=stVal not found in DataTypeTemplate",
-                                "/SCL/IED[@name=\"IED_NAME3\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]")
+                                "SCL/IED[@name=\"IED_NAME3\"]/AccessPoint/Server/LDevice[@inst=\"LDEPF\"]")
                 );
     }
 

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapterTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/ied/InputsAdapterTest.java
@@ -23,14 +23,11 @@ import org.lfenergy.compas.sct.commons.util.CsvUtils;
 import org.opentest4j.AssertionFailedError;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Named.named;
 import static org.lfenergy.compas.sct.commons.testhelpers.SclHelper.*;
 
@@ -308,6 +305,17 @@ class InputsAdapterTest {
         // Then
         assertThat(result).hasSameSizeAs(tExtRefList)
                 .hasSize(6);
+    }
+
+    @Test
+    void updateAllExtRefIedNames_when_DOI_Mod_and_DAI_stVal_notExists_should_not_produce_error() {
+        // Given
+        SCL scl = SclTestMarshaller.getSCLFromFile("/scd-refresh-lnode/Test_Missing_ModstVal_In_LN0_when_binding.scd");
+        InputsAdapter inputsAdapter = findInputs(scl, "IedName1", "LDSUIED");
+        // When
+        List<SclReportItem> sclReportItems = inputsAdapter.updateAllExtRefIedNames(Map.of());
+        // Then
+        assertThat(sclReportItems).isEmpty();
     }
 
 }

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/ldevice/LDeviceAdapterTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/scl/ldevice/LDeviceAdapterTest.java
@@ -33,10 +33,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter.MOD_DO_TYPE_NAME;
-import static org.lfenergy.compas.sct.commons.scl.ln.AbstractLNAdapter.STVAL_DA_TYPE_NAME;
 import static org.lfenergy.compas.sct.commons.testhelpers.SclHelper.*;
-import static org.lfenergy.compas.sct.commons.util.CommonConstants.LDEVICE_LDEPF;
 import static org.lfenergy.compas.sct.commons.util.ControlBlockEnum.*;
 import static org.lfenergy.compas.sct.commons.util.Utils.copySclElement;
 
@@ -607,70 +604,6 @@ class LDeviceAdapterTest {
                 .hasSize(2)
                 .extracting(TVal::getValue)
                 .containsExactly("LD_Name/LLN0.CB_Name_1", "LD_Name/LLN0.CB_Name_2");
-    }
-
-    @Test
-    void getExtRefBuyReferenceForActifLDEPF_when_LDEPF_active_and_bay_exists_should_return_existingExtRef() {
-        // Given
-        SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_extrefbayRef.xml");
-        SclRootAdapter sclRootAdapter = new SclRootAdapter(scd);
-        LDeviceAdapter lDeviceAdapter = sclRootAdapter.getIEDAdapterByName("IED_NAME1").getLDeviceAdapterByLdInst("LDEPF");
-        // When
-        List<SclReportItem> sclReportItems = new ArrayList<>();
-        List<ExtRefInfo.ExtRefBayReference> extRefBayReferences = lDeviceAdapter.getExtRefBayReferenceForActifLDEPF(sclReportItems);
-        // Then
-        assertThat(extRefBayReferences).hasSize(1);
-        assertThat(sclReportItems).isEmpty();
-    }
-
-    @Test
-    void getExtRefBayReferenceForActifLDEPF_when_NoPrivateBuyNorIcdHeader_should_return_fatal_errors() {
-        // Given
-        SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_extrefbayRef.xml");
-        SclRootAdapter sclRootAdapter = new SclRootAdapter(scd);
-        IEDAdapter iedAdapter = sclRootAdapter.getIEDAdapterByName("IED_NAME1");
-        iedAdapter.getCurrentElem().getPrivate().clear();
-        LDeviceAdapter lDeviceAdapter = iedAdapter.getLDeviceAdapterByLdInst("LDEPF");
-        // When
-        List<SclReportItem> sclReportItems = new ArrayList<>();
-        List<ExtRefInfo.ExtRefBayReference> extRefBayReferences = lDeviceAdapter.getExtRefBayReferenceForActifLDEPF(sclReportItems);
-        // Then
-        assertThat(extRefBayReferences).isEmpty();
-        assertThat(sclReportItems).hasSize(2);
-        assertThat(sclReportItems)
-                .extracting(SclReportItem::message)
-                .contains("The IED has no Private Bay", "The IED has no Private compas:ICDHeader");
-    }
-
-    @Test
-    void getExtRefBayReferenceForActifLDEPF_when_DOI_Mod_notExists_should_return_fatal_errors() {
-        // Given
-        SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_extrefbayRef.xml");
-        SclRootAdapter sclRootAdapter = new SclRootAdapter(scd);
-        LDeviceAdapter lDeviceAdapter = sclRootAdapter.getIEDAdapterByName("IED_NAME3").getLDeviceAdapterByLdInst("LDEPF");
-        // When
-        List<SclReportItem> sclReportItems = new ArrayList<>();
-        List<ExtRefInfo.ExtRefBayReference> extRefBayReferences = lDeviceAdapter.getExtRefBayReferenceForActifLDEPF(sclReportItems);
-        // Then
-        assertThat(extRefBayReferences).isEmpty();
-        assertThat(sclReportItems).hasSize(1);
-        assertThat(sclReportItems)
-                .extracting(SclReportItem::message)
-                .containsExactly("There is no DOI@name=" + MOD_DO_TYPE_NAME + "/DAI@name=" + STVAL_DA_TYPE_NAME + "/Val for LDevice@inst" + LDEVICE_LDEPF);
-    }
-
-    @Test
-    void getExtRefBayReferenceForActifLDEPF_when_LDEPF_NotActive_should_not_return_existingExtRef() {
-        // Given
-        SCL scd = SclTestMarshaller.getSCLFromFile("/scd-ldepf/scd_ldepf_extrefbayRef.xml");
-        SclRootAdapter sclRootAdapter = new SclRootAdapter(scd);
-        LDeviceAdapter lDeviceAdapter = sclRootAdapter.getIEDAdapterByName("IED_NAME2").getLDeviceAdapterByLdInst("LDEPF");
-        // When
-        List<SclReportItem> sclReportItems = new ArrayList<>();
-        List<ExtRefInfo.ExtRefBayReference> extRefBayReferences = lDeviceAdapter.getExtRefBayReferenceForActifLDEPF(sclReportItems);
-        // Then
-        assertThat(extRefBayReferences).isEmpty();
-        assertThat(sclReportItems).isEmpty();
     }
 
     private static Stream<Arguments> provideLnClassAndDoType() {

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_withoutModStValInDataTypeTemplate.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_withoutModStValInDataTypeTemplate.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
+    <Private type="COMPAS-SclFileType">
+        <compas:SclFileType>SCD</compas:SclFileType>
+    </Private>
+    <Header id="hId" version="2007" revision="B" toolID="COMPAS"/>
+    <IED name="IEDTEST">
+        <AccessPoint name="AP_NAME"/>
+    </IED>
+    <IED name="IED_NAME1">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME1LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC"
+                                    desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                    <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+                </LDevice>
+                <LDevice inst="LDEVICE_INVALID" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME2">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID2" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME2LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME3">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="2"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME3LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME3LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <DataTypeTemplates>
+        <LNodeType lnClass="LLN0" id="LLN0_ID1">
+            <DO name="Beh" type="DO2"/>
+        </LNodeType>
+        <LNodeType lnClass="PTRC" id="PTRC_ID1">
+            <DO name="Mod" type="DO2"/>
+            <DO name="Str" type="ACD1"/>
+        </LNodeType>
+        <LNodeType lnClass="RBDR" id="RTE_RBDR">
+            <DO name="ChNum1" type="DOCh"/>
+            <DO name="LevMod" type="DOLe"/>
+            <DO name="Mod" type="DOMo"/>
+            <DO name="SrcRef" type="DOSr"/>
+        </LNodeType>
+        <DOType cdc="ACD" id="ACD1">
+            <DA name="general" bType="BOOLEAN" fc="ST"/>
+        </DOType>
+        <DOType cdc="ENC" id="DO2">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind"
+                valImport="true"/>
+            <DA fc="BL" name="daName1" bType="BOOLEAN"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOCh">
+            <DA fc="ST" dchg="true" name="dU" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOLe">
+            <DA fc="ST" dchg="true" name="setVal" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOMo">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOSr">
+            <DA fc="ST" dchg="true" name="setSrcRef" bType="VisString255" valImport="true"/>
+        </DOType>
+        <EnumType id="BehaviourModeKind">
+            <EnumVal ord="1">on</EnumVal>
+            <EnumVal ord="2">off</EnumVal>
+            <EnumVal ord="3">blocked</EnumVal>
+            <EnumVal ord="4">test</EnumVal>
+            <EnumVal ord="5">test/blocked</EnumVal>
+        </EnumType>
+    </DataTypeTemplates>
+</SCL>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_withoutModStValInLN0.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_withoutModStValInLN0.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
+    <Private type="COMPAS-SclFileType">
+        <compas:SclFileType>SCD</compas:SclFileType>
+    </Private>
+    <Header id="hId" version="2007" revision="B" toolID="COMPAS"/>
+    <IED name="IEDTEST">
+        <AccessPoint name="AP_NAME"/>
+    </IED>
+    <IED name="IED_NAME1">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME1LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC"
+                                    desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                    <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+                </LDevice>
+                <LDevice inst="LDEVICE_INVALID" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME2">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID2" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME2LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME3">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="2"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME3LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME3LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <DataTypeTemplates>
+        <LNodeType lnClass="LLN0" id="LLN0_ID1">
+            <DO name="Mod" type="DO2"/>
+        </LNodeType>
+        <LNodeType lnClass="PTRC" id="PTRC_ID1">
+            <DO name="Mod" type="DO2"/>
+            <DO name="Str" type="ACD1"/>
+        </LNodeType>
+        <LNodeType lnClass="RBDR" id="RTE_RBDR">
+            <DO name="ChNum1" type="DOCh"/>
+            <DO name="LevMod" type="DOLe"/>
+            <DO name="Mod" type="DOMo"/>
+            <DO name="SrcRef" type="DOSr"/>
+        </LNodeType>
+        <DOType cdc="ACD" id="ACD1">
+            <DA name="general" bType="BOOLEAN" fc="ST"/>
+        </DOType>
+        <DOType cdc="ENC" id="DO2">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind"
+                valImport="true"/>
+            <DA fc="BL" name="daName1" bType="BOOLEAN"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOCh">
+            <DA fc="ST" dchg="true" name="dU" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOLe">
+            <DA fc="ST" dchg="true" name="setVal" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOMo">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOSr">
+            <DA fc="ST" dchg="true" name="setSrcRef" bType="VisString255" valImport="true"/>
+        </DOType>
+        <EnumType id="BehaviourModeKind">
+            <EnumVal ord="1">on</EnumVal>
+            <EnumVal ord="2">off</EnumVal>
+            <EnumVal ord="3">blocked</EnumVal>
+            <EnumVal ord="4">test</EnumVal>
+            <EnumVal ord="5">test/blocked</EnumVal>
+        </EnumType>
+    </DataTypeTemplates>
+</SCL>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_with_inactive_ldevice_ldepf.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_with_inactive_ldevice_ldepf.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
+    <Private type="COMPAS-SclFileType">
+        <compas:SclFileType>SCD</compas:SclFileType>
+    </Private>
+    <Header id="hId" version="2007" revision="B" toolID="COMPAS"/>
+    <IED name="IEDTEST">
+        <AccessPoint name="AP_NAME"/>
+    </IED>
+    <IED name="IED_NAME1">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME1LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC"
+                                    desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                    <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN>
+                </LDevice>
+                <LDevice inst="LDEVICE_INVALID" ldName="IED_NAME1LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME2">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID2" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="1"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME2LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <IED name="IED_NAME3">
+        <Private type="COMPAS-Bay">
+            <compas:Bay UUID="bayUUID1" BayCodif="CB00001101" NumBay="1" BayCount="1" MainShortLabel="aa"/>
+        </Private>
+        <Private type="COMPAS-ICDHeader">
+            <compas:ICDHeader IEDType="BCU" IEDredundancy="None" IEDSystemVersioninstance="2"
+                              ICDSystemVersionUUID="System_Version_IED_NAME1" VendorName="SCLE SFE" IEDmodel="ARKENS-SV1120-HGAAA-EB5" hwRev="1.0" swRev="1.0"
+                              headerId="ARKENS-SV1120-HGAAA-EB5_SCU"/>
+        </Private>
+        <AccessPoint name="AP_NAME">
+            <Server>
+                <Authentication/>
+                <LDevice inst="LDEPF" ldName="IED_NAME3LDEPF">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal" valImport="true">
+                                <Val>off</Val>
+                            </DAI>
+                        </DOI>
+                        <Inputs>
+                            <ExtRef intAddr="INT_ADDR11" pDO="Str" pLN="PTRC" desc="DYN_LDEPF_DIGITAL CHANNEL 1_1_BOOLEEN_1_general_1"/>
+                        </Inputs>
+                    </LN0>
+                </LDevice>
+                <LDevice inst="LDPX" ldName="IED_NAME3LDPX">
+                    <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <DOI name="Mod">
+                            <DAI name="stVal">
+                                <Val>on</Val>
+                            </DAI>
+                        </DOI>
+
+                    </LN0>
+                    <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
+                    </LN>
+                </LDevice>
+            </Server>
+        </AccessPoint>
+    </IED>
+    <DataTypeTemplates>
+        <LNodeType lnClass="LLN0" id="LLN0_ID1">
+            <DO name="Mod" type="DO2"/>
+        </LNodeType>
+        <LNodeType lnClass="PTRC" id="PTRC_ID1">
+            <DO name="Mod" type="DO2"/>
+            <DO name="Str" type="ACD1"/>
+        </LNodeType>
+        <LNodeType lnClass="RBDR" id="RTE_RBDR">
+            <DO name="ChNum1" type="DOCh"/>
+            <DO name="LevMod" type="DOLe"/>
+            <DO name="Mod" type="DOMo"/>
+            <DO name="SrcRef" type="DOSr"/>
+        </LNodeType>
+        <DOType cdc="ACD" id="ACD1">
+            <DA name="general" bType="BOOLEAN" fc="ST"/>
+        </DOType>
+        <DOType cdc="ENC" id="DO2">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind"
+                valImport="true"/>
+            <DA fc="BL" name="daName1" bType="BOOLEAN"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOCh">
+            <DA fc="ST" dchg="true" name="dU" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOLe">
+            <DA fc="ST" dchg="true" name="setVal" bType="VisString255" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOMo">
+            <DA fc="ST" dchg="true" name="stVal" bType="Enum" type="BehaviourModeKind" valImport="true"/>
+        </DOType>
+        <DOType cdc="ENC" id="DOSr">
+            <DA fc="ST" dchg="true" name="setSrcRef" bType="VisString255" valImport="true"/>
+        </DOType>
+        <EnumType id="BehaviourModeKind">
+            <EnumVal ord="1">on</EnumVal>
+            <EnumVal ord="2">off</EnumVal>
+            <EnumVal ord="3">blocked</EnumVal>
+            <EnumVal ord="4">test</EnumVal>
+            <EnumVal ord="5">test/blocked</EnumVal>
+        </EnumType>
+    </DataTypeTemplates>
+</SCL>

--- a/sct-commons/src/test/resources/scd-refresh-lnode/Test_Missing_ModstVal_In_LN0_when_binding.scd
+++ b/sct-commons/src/test/resources/scd-refresh-lnode/Test_Missing_ModstVal_In_LN0_when_binding.scd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- SPDX-FileCopyrightText: 2022 RTE FRANCE -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<SCL xmlns:compas="https://www.lfenergy.org/compas/extension/v1" xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+	<Private type="COMPAS-SclFileType">
+		<compas:SclFileType>SCD</compas:SclFileType>
+	</Private>
+	<Header id="9ff3be19-a353-4b9c-b71b-af133855336a" version="5" revision="A" toolID="COMPAS">
+		<History>
+			<Hitem version="5" revision="A" when="Tue Aug 23 10:37:48 CEST 2022" who="" what="" why="" />
+		</History>
+	</Header>
+	<Substation name="SITE">
+		<Private type="RTE-ExportSite">
+			<rte:ExportSite xmlns:rte="http://www.rte-france.com" Indice="2" Label="PALLU" UUID="d66637d5-2387-409e-99c3-f3d67079013a" />
+		</Private>
+		<VoltageLevel nomFreq="50" numPhases="3" name="0">
+			<Voltage unit="V" multiplier="k">0</Voltage>
+			<Bay name="BAY_1">
+				<Private type="COMPAS-Bay">
+					<compas:Bay BayCodif="TG00000001" UUID="9cd6f05b-1bbd-4ba3-86c5-41c99103e06d" Version="1"
+								MainShortLabel="SITE1" SecondLabel="SITE-TGENE" NumBay="7" BayCount="1"/>
+				</Private>
+				<Private type="COMPAS-Criteria">
+					<compas:Criteria ObjectID="9cd6f05b-1bbd-4ba3-86c5-41c99103e06d" CriteriaAssociationID="CriteriaAssociationID" />
+				</Private>
+				<Function name="FUNCTION_1">
+					<Private type="COMPAS-Function">
+						<compas:Function UUID="8f4cda3f-828c-4006-9b87-2af96b19304b" Label="FUNCTION_1" />
+					</Private>
+					<LNode iedName="IedName1" ldInst="LDSUIED" lnClass="LLN0" lnInst="">
+						<Private type="COMPAS-ICDHeader">
+							<compas:ICDHeader ICDSystemVersionUUID="IED4d4fe1a8cda64cf88a5ee4176a1a0eed"
+											  IEDSystemVersioninstance="1" IEDType="SAMU" IEDSubstationinstance="3"
+											  IEDName="IedName1" VendorName="RTE" IEDmodel="ICDfromModeling"
+											  IEDredundancy="B" BayLabel="SITE1" hwRev="01.00.00" swRev="01.00.00"
+											  headerId="cacfa2df-bdb2-47a7-b7ea-07916586ebdd" headerVersion="01.00.00"
+											  headerRevision="01.00.00"/>
+						</Private>
+					</LNode>
+				</Function>
+			</Bay>
+		</VoltageLevel>
+	</Substation>
+	<Communication>
+		<SubNetwork type="8-MMS" name="RSPACE_PROCESS_NETWORK">
+			<ConnectedAP iedName="IedName1" apName="PROCESS_AP">
+				<Address>
+					<P type="OSI-PSEL">00000001</P>
+				</Address>
+			</ConnectedAP>
+		</SubNetwork>
+		<SubNetwork type="IP" name="RSPACE_ADMIN_NETWORK">
+			<ConnectedAP iedName="IedName1" apName="ADMIN_AP">
+				<Address>
+					<P type="SyslogIP">Adresse IP du serveur Syslog</P>
+				</Address>
+			</ConnectedAP>
+		</SubNetwork>
+	</Communication>
+	<IED name="IedName1" type="Valeur définie par le fournisseur" manufacturer="ADU" configVersion="ADU" originalSclVersion="2007" originalSclRevision="B" originalSclRelease="4" owner="ADU">
+		<Private type="RTE-IEDType">SAMU</Private>
+		<Private type="COMPAS-IEDType">SAMU</Private>
+		<Private type="COMPAS-SystemVersion">
+			<compas:SystemVersion MainSystemVersion="01.00" MinorSystemVersion="009.001.001" />
+		</Private>
+		<Private type="COMPAS-ICDHeader">
+			<compas:ICDHeader ICDSystemVersionUUID="IED4d4fe1a8cda64cf88a5ee4176a1a0eed" IEDSystemVersioninstance="1"
+							  IEDType="SAMU" IEDSubstationinstance="3" IEDName="IedName1" VendorName="RTE"
+							  IEDmodel="ICDfromModeling" IEDredundancy="B" BayLabel="SITE1" hwRev="01.00.00"
+							  swRev="01.00.00" headerId="cacfa2df-bdb2-47a7-b7ea-07916586ebdd" headerVersion="01.00.00"
+							  headerRevision="01.00.00"/>
+		</Private>
+		<AccessPoint name="PROCESS_AP">
+			<Server>
+				<Authentication />
+				<LDevice inst="LDSUIED" ldName="IedName1LDSUIED" desc="IED Monitoring Function">
+					<Private type="COMPAS-LDevice">
+						<compas:LDevice xmlns:compas="https://www.lfenergy.org/compas/extension/v1" LDeviceID="IedName1LDSUIED" LDeviceStatus="ACTIVE"/>
+					</Private>
+					<LN0 lnClass="LLN0" inst="" lnType="LNType1" desc="Logical node zero">
+						<DOI name="NamPlt">
+							<DAI name="swRev">
+								<Val>01.00.000</Val>
+							</DAI>
+							<DAI name="configRev">
+								<Val>01.00.000</Val>
+							</DAI>
+						</DOI>
+						<Inputs>
+							<ExtRef desc="extRef1" srcLDInst="srcLDInst0" srcPrefix="srcPrefix0" srcLNClass="ANCR" srcLNInst="0" srcCBName="srcCBName0"/>
+							<ExtRef desc="extRef2" srcLDInst="srcLDInst1" srcPrefix="srcPrefix1" srcLNClass="ARIS" srcLNInst="1" srcCBName="srcCBName1"/>
+						</Inputs>
+					</LN0>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+		<AccessPoint name="ADMIN_AP" />
+	</IED>
+
+	<DataTypeTemplates>
+		<LNodeType lnClass="LLN0" id="LNType1">
+			<DO name="NamPlt" type="DO1" transient="false" />
+			<DO name="Mod" type="DO2" transient="false" />
+			<DO name="Beh" type="DO2" transient="false" />
+		</LNodeType>
+		<DOType cdc="LPL" id="DO1">
+			<DA fc="DC" dchg="false" qchg="false" dupd="false" name="configRev" bType="VisString255" valKind="RO" valImport="false" />
+			<DA fc="DC" dchg="false" qchg="false" dupd="false" name="swRev" bType="VisString255" valKind="RO" valImport="false" />
+		</DOType>
+		<DOType cdc="ENC" id="DO2">
+			<DA fc="ST" dchg="true" qchg="false" dupd="false" name="stVal" bType="Enum" type="BehaviourModeKind" valImport="true" />
+		</DOType>
+		<EnumType id="BehaviourModeKind">
+			<EnumVal ord="2">blocked</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="4">test/blocked</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
+			<EnumVal ord="1">on</EnumVal>
+		</EnumType>
+
+	</DataTypeTemplates>
+</SCL>


### PR DESCRIPTION
This pull tries to remove validation when DOI(Mod) and DAI(stVal) does not exists:

Changes in existing issues:

1. [Remove the binding when source or target IED is off or signal is Inactive - Part 2/3](https://github.com/com-pas/compas-sct/issues/78)
> Error messages:
> 
> If the status of the source LDevice ou the target LDevice is not defined then the processing is aborted and an error message is returned: "The IED@name/LDevice@inst has no "on" or "off" status. End of the processing".

==> Error message removed and the LDevice considered as "on"

2. [Setting of LDEPF LDevices and its RADR and RBDR Logical Nodes](https://github.com/com-pas/compas-sct/issues/256)
> Functional Rules
>Description:
> 
>Step 1 : In SCD file, find all LDevice@inst="LDEPF" which are active. Then find each IED@name and Bay UUID where these LDEPF LDevice reside. Exclude the IED@name="IEDTEST" and its LDEPF LDevice. If there is no DOI@name="Mod"/DAI@name="stVal"/Val then an error message is returned ERR_01

==> Error message (ERR_01) removed and the LDevice considered as "on", Maintaining the verification in DataTypeTemplate of DO(Mod)/DA(stVal)