### PR TITLE
fix(#470) : completeFromDAInstance should replace dataTypeTemplate Val by DAI Val

### DIFF
--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DoTypeService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/DoTypeService.java
@@ -36,7 +36,7 @@ public class DoTypeService {
         List<DoLinkedToDa> result = new ArrayList<>();
         // DA -> BDA -> BDA..
         sdoOrDAService.getDAs(tdoType).forEach(tda -> {
-            DoLinkedToDa doLinkedToDa = DoLinkedToDa.copyFrom(doLinkedToDaTemplate);
+            DoLinkedToDa doLinkedToDa = doLinkedToDaTemplate.deepCopy();
             doLinkedToDa.dataAttribute().setDaName(tda.getName());
             if (tda.isSetFc()) {
                 doLinkedToDa.dataAttribute().setFc(tda.getFc());
@@ -57,7 +57,7 @@ public class DoTypeService {
                     if (tsdo.isSetType()) {
                         findDoType(dtt, tdoType1 -> tdoType1.getId().equals(tsdo.getType()))
                                 .ifPresent(nextDoType -> {
-                                    DoLinkedToDa newDoLinkedToDa = DoLinkedToDa.copyFrom(doLinkedToDaTemplate);
+                                    DoLinkedToDa newDoLinkedToDa = doLinkedToDaTemplate.deepCopy();
                                     newDoLinkedToDa.dataObject().getSdoNames().add(tsdo.getName());
                                     if (nextDoType.isSetCdc()) {
                                         newDoLinkedToDa.dataObject().setCdc(nextDoType.getCdc());
@@ -73,7 +73,7 @@ public class DoTypeService {
         // BDA -> BDA -> BDA..
         return bdaService.getBDAs(tdaType1)
                 .flatMap(tbda -> {
-                    DoLinkedToDa newDoLinkedToDa = DoLinkedToDa.copyFrom(doLinkedToDaTemplate);
+                    DoLinkedToDa newDoLinkedToDa = doLinkedToDaTemplate.deepCopy();
                     newDoLinkedToDa.dataAttribute().getBdaNames().add(tbda.getName());
 
                     // STRUCT type (BType=STRUCT) refer to complex BDA object, otherwise it is kind of DA object

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/LnService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/LnService.java
@@ -146,13 +146,15 @@ public class LnService implements LnEditor {
                 });
     }
 
-    public void completeFromDAInstance(TIED tied, String ldInst, TAnyLN anyLN, DoLinkedToDa doLinkedToDa) {
+    @Override
+    public DoLinkedToDa getDoLinkedToDaCompletedFromDAI(TIED tied, String ldInst, TAnyLN anyLN, DoLinkedToDa doLinkedToDa) {
+        DoLinkedToDa result = doLinkedToDa.deepCopy();
         getDOAndDAInstances(anyLN, doLinkedToDa.toFilter())
                 .ifPresent(tdai -> {
                     if (tdai.isSetVal()) {
-                        doLinkedToDa.dataAttribute().addDaVal(tdai.getVal());
+                        result.dataAttribute().addDaVal(tdai.getVal());
                     }
-                    if (doLinkedToDa.dataAttribute().getFc() == TFCEnum.SG || doLinkedToDa.dataAttribute().getFc() == TFCEnum.SE) {
+                    if (result.dataAttribute().getFc() == TFCEnum.SG || result.dataAttribute().getFc() == TFCEnum.SE) {
                         if (hasSettingGroup(tdai)) {
                             boolean isIedHasConfSG = tied.isSetAccessPoint() &&
                                     tied.getAccessPoint().stream()
@@ -163,15 +165,16 @@ public class LnService implements LnEditor {
                                                     && tAccessPoint.getServices() != null
                                                     && tAccessPoint.getServices().getSettingGroups() != null
                                                     && tAccessPoint.getServices().getSettingGroups().getConfSG() != null);
-                            doLinkedToDa.dataAttribute().setValImport((!tdai.isSetValImport() || tdai.isValImport()) && isIedHasConfSG);
+                            result.dataAttribute().setValImport((!tdai.isSetValImport() || tdai.isValImport()) && isIedHasConfSG);
                         } else {
-                            log.warn(String.format("Inconsistency in the SCD file - DAI= %s with fc= %s must have a sGroup attribute", tdai.getName(), doLinkedToDa.dataAttribute().getFc()));
-                            doLinkedToDa.dataAttribute().setValImport(false);
+                            log.warn("Inconsistency in the SCD file - DAI= {} with fc= {} must have a sGroup attribute", tdai.getName(), result.dataAttribute().getFc());
+                            result.dataAttribute().setValImport(false);
                         }
                     } else if (tdai.isSetValImport()) {
-                        doLinkedToDa.dataAttribute().setValImport(tdai.isValImport());
+                        result.dataAttribute().setValImport(tdai.isValImport());
                     }
                 });
+        return result;
     }
 
     public boolean matchesLn(TAnyLN tAnyLN, String lnClass, String lnInst, String lnPrefix) {

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/api/LnEditor.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/api/LnEditor.java
@@ -6,6 +6,7 @@ package org.lfenergy.compas.sct.commons.api;
 
 import org.lfenergy.compas.scl2007b4.model.TAnyLN;
 import org.lfenergy.compas.scl2007b4.model.TDAI;
+import org.lfenergy.compas.scl2007b4.model.TIED;
 import org.lfenergy.compas.sct.commons.domain.DoLinkedToDa;
 import org.lfenergy.compas.sct.commons.domain.DoLinkedToDaFilter;
 import org.lfenergy.compas.sct.commons.util.ActiveStatus;
@@ -22,4 +23,5 @@ public interface LnEditor {
 
     void updateOrCreateDOAndDAInstances(TAnyLN tAnyLN, DoLinkedToDa doLinkedToDa);
 
+    DoLinkedToDa getDoLinkedToDaCompletedFromDAI(TIED tied, String ldInst, TAnyLN anyLN, DoLinkedToDa doLinkedToDa);
 }

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DataAttribute.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DataAttribute.java
@@ -13,6 +13,7 @@ import org.lfenergy.compas.scl2007b4.model.TVal;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -26,19 +27,24 @@ public class DataAttribute {
     private List<String> bdaNames = new ArrayList<>();
     private List<DaVal> daiValues = new ArrayList<>();
 
-    public static DataAttribute copyFrom(DataAttribute dataAttribute) {
-        DataAttribute dataAttribute1 = new DataAttribute();
-        dataAttribute1.setDaName(dataAttribute.getDaName());
-        dataAttribute1.setFc(dataAttribute.getFc());
-        dataAttribute1.setBType(dataAttribute.getBType());
-        dataAttribute1.setType(dataAttribute.getType());
-        dataAttribute1.getBdaNames().addAll(dataAttribute.getBdaNames());
-        dataAttribute1.setValImport(dataAttribute.isValImport());
-        return dataAttribute1;
+    public DataAttribute deepCopy() {
+        DataAttribute dataAttribute = new DataAttribute();
+        dataAttribute.setDaName(getDaName());
+        dataAttribute.setType(getType());
+        dataAttribute.setBType(getBType());
+        dataAttribute.setFc(getFc());
+        dataAttribute.setValImport(isValImport());
+        dataAttribute.getBdaNames().addAll(getBdaNames());
+        dataAttribute.getDaiValues().addAll(getDaiValues());
+        return dataAttribute;
     }
 
     public void addDaVal(List<TVal> vals) {
-       vals.forEach(tVal -> daiValues.add(new DaVal(tVal.isSetSGroup() ? tVal.getSGroup() : null, tVal.getValue())));
+        vals.forEach(tVal -> {
+            Long settingGroup = tVal.isSetSGroup() ? tVal.getSGroup() : null;
+            daiValues.removeIf(daVal -> Objects.equals(daVal.settingGroup(), settingGroup));
+            daiValues.add(new DaVal(settingGroup, tVal.getValue()));
+        });
     }
 
     @Override

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DataObject.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DataObject.java
@@ -28,8 +28,8 @@ public class DataObject {
         this.sdoNames.addAll(sdoNames);
     }
 
-    public static DataObject copyFrom(DataObject dataObject) {
-        return new DataObject(dataObject.getDoName(), dataObject.getCdc(), dataObject.getSdoNames());
+    public DataObject deepCopy() {
+        return new DataObject(getDoName(), getCdc(), getSdoNames());
     }
 
     @Override

--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DoLinkedToDa.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/domain/DoLinkedToDa.java
@@ -11,10 +11,10 @@ import static org.lfenergy.compas.sct.commons.util.CommonConstants.STVAL_DA_NAME
 
 public record DoLinkedToDa(DataObject dataObject, DataAttribute dataAttribute) {
 
-    public static DoLinkedToDa copyFrom(DoLinkedToDa doLinkedToDa) {
+    public DoLinkedToDa deepCopy() {
         return new DoLinkedToDa(
-                DataObject.copyFrom(doLinkedToDa.dataObject()),
-                DataAttribute.copyFrom(doLinkedToDa.dataAttribute()));
+                dataObject().deepCopy(),
+                dataAttribute().deepCopy());
     }
 
     public String getDoRef() {

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/domain/DataAttributeTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/domain/DataAttributeTest.java
@@ -7,7 +7,10 @@ package org.lfenergy.compas.sct.commons.domain;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.lfenergy.compas.scl2007b4.model.TFCEnum;
+import org.lfenergy.compas.sct.commons.util.SclConstructorHelper;
 
 import java.util.List;
 
@@ -69,7 +72,38 @@ class DataAttributeTest {
         dataAttribute.setFc(TFCEnum.valueOf(fcVal));
         // When Then
         assertThat(dataAttribute.isUpdatable()).isEqualTo(expected);
+    }
 
+    @Test
+    void addDaVal_should_add_Val() {
+        // Given
+        DataAttribute dataAttribute = new DataAttribute();
+        // When
+        dataAttribute.addDaVal(List.of(SclConstructorHelper.newVal("value", null)));
+        // Then
+        assertThat(dataAttribute.getDaiValues()).containsExactly(new DaVal(null, "value"));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(longs = 5L)
+    void addDaVal_should_replace_Val_with_same_sGroup(Long sGroup) {
+        // Given
+        DataAttribute dataAttribute = new DataAttribute();
+        dataAttribute.addDaVal(List.of(
+                SclConstructorHelper.newVal("old value 1", 1L),
+                SclConstructorHelper.newVal("old value 2", 2L),
+                SclConstructorHelper.newVal("old value sGroup", sGroup)
+        ));
+        // When
+        dataAttribute.addDaVal(List.of(SclConstructorHelper.newVal("new value sGroup", sGroup)));
+        // Then
+        assertThat(dataAttribute.getDaiValues())
+                .containsExactlyInAnyOrder(
+                        new DaVal(sGroup, "new value sGroup"),
+                        new DaVal(1L, "old value 1"),
+                        new DaVal(2L, "old value 2")
+                );
     }
 
 }

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/domain/DoLinkedToDaTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/domain/DoLinkedToDaTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class DoLinkedToDaTest {
 
     @Test
-    void test_copyFrom() {
+    void test_deepCopy() {
         // Given
         DataObject dataObject = new DataObject();
         dataObject.setDoName("doName");
@@ -28,7 +28,7 @@ class DoLinkedToDaTest {
         dataAttribute.setFc(TFCEnum.BL);
         DoLinkedToDa doLinkedToDa = new DoLinkedToDa(dataObject, dataAttribute);
         // When
-        DoLinkedToDa newDoLinkedToDa = DoLinkedToDa.copyFrom(doLinkedToDa);
+        DoLinkedToDa newDoLinkedToDa = doLinkedToDa.deepCopy();
         // Then
         assertAll("Copy From",
                 () -> assertThat(newDoLinkedToDa.dataObject().getCdc()).isEqualTo(doLinkedToDa.dataObject().getCdc()),

--- a/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/dto/DataAttributeRefTest.java
+++ b/sct-commons/src/test/java/org/lfenergy/compas/sct/commons/dto/DataAttributeRefTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Named.named;
 import static org.lfenergy.compas.sct.commons.testhelpers.DataTypeUtils.createDa;
 import static org.lfenergy.compas.sct.commons.util.CommonConstants.MOD_DO_NAME;
 import static org.lfenergy.compas.sct.commons.util.CommonConstants.STVAL_DA_NAME;
@@ -139,7 +140,7 @@ class DataAttributeRefTest {
 
     @Test
     @Tag("issue-321")
-    void testCopyFrom() {
+    void testDeepCopy() {
         // Given
         DataAttributeRef dataAttributeRef = DTO.createDataAttributeRef("pre","lnclass","1");
         // When
@@ -186,7 +187,7 @@ class DataAttributeRefTest {
      */
     @ParameterizedTest
     @MethodSource("daParametersProviderUpdatable")
-    void isUpdatable_case0(String testName, String daName, TFCEnum fc, boolean valImport) {
+    void isUpdatable_case0(String daName, TFCEnum fc, boolean valImport) {
         //Given
         DataAttributeRef dataAttributeRef = new DataAttributeRef();
         dataAttributeRef.setDoName(new DoTypeName(MOD_DO_NAME));
@@ -201,19 +202,19 @@ class DataAttributeRefTest {
 
     private static Stream<Arguments> daParametersProviderUpdatable() {
         return Stream.of(
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, TFCEnum.CF, true),
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, TFCEnum.CF, false),
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, TFCEnum.MX, true),
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, TFCEnum.MX, false),
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, null, true),
-                Arguments.of("should return true when Mod", STVAL_DA_NAME, null, false),
-                Arguments.of("should return true when Mod", "ctlModel", TFCEnum.CF, true)
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), TFCEnum.CF, true),
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), TFCEnum.CF, false),
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), TFCEnum.MX, true),
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), TFCEnum.MX, false),
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), null, true),
+                Arguments.of(named("should return true when Mod", STVAL_DA_NAME), null, false),
+                Arguments.of(named("should return true when Mod", "ctlModel"), TFCEnum.CF, true)
         );
     }
 
     @ParameterizedTest
     @MethodSource("daParametersProviderNotUpdatable")
-    void isUpdatable_case1(String testName, String daName, TFCEnum fc, boolean valImport) {
+    void isUpdatable_case1(String daName, TFCEnum fc, boolean valImport) {
         //Given
         DataAttributeRef dataAttributeRef = new DataAttributeRef();
         dataAttributeRef.setDoName(new DoTypeName(MOD_DO_NAME));
@@ -228,11 +229,11 @@ class DataAttributeRefTest {
 
     private static Stream<Arguments> daParametersProviderNotUpdatable() {
         return Stream.of(
-                Arguments.of("should return false when Mod", "ctlModel", TFCEnum.CF, false),
-                Arguments.of("should return false when Mod", "ctlModel", TFCEnum.MX, true),
-                Arguments.of("should return false when Mod", "ctlModel", TFCEnum.MX, false),
-                Arguments.of("should return false when Mod", "ctlModel", null, true),
-                Arguments.of("should return false when Mod", "ctlModel", null, false)
+                Arguments.of(named("should return false when Mod", "ctlModel"), TFCEnum.CF, false),
+                Arguments.of(named("should return false when Mod", "ctlModel"), TFCEnum.MX, true),
+                Arguments.of(named("should return false when Mod", "ctlModel"), TFCEnum.MX, false),
+                Arguments.of(named("should return false when Mod", "ctlModel"), null, true),
+                Arguments.of(named("should return false when Mod", "ctlModel"), null, false)
         );
     }
 


### PR DESCRIPTION
- Fix issue #470 
- Change signature of completeFromDAInstance to return new instance, so we can use it in `.map` and to reduce mutation on DoLinkedToDa (I hope some day DoLinkedToDa will be completely immutable).