### PR TITLE
feat: LDEPF used COMPAS-LNodeStatus of Source LDevice and LN instead of Mod.stVal for sources consideration, closes #514, RSR-1243

### DIFF
--- a/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
+++ b/sct-commons/src/main/java/org/lfenergy/compas/sct/commons/ExtRefEditorService.java
@@ -147,7 +147,7 @@ public class ExtRefEditorService implements ExtRefEditor {
      */
     private Optional<LDeviceAdapter> getActiveSourceLDeviceByLDEPFChannel(IEDAdapter iedAdapter, TChannel channel) {
         return ldeviceService.findLdevice(iedAdapter.getCurrentElem(), channel.getLDInst())
-                .filter(tlDevice -> ldeviceService.getLdeviceStatus(tlDevice).map(ActiveStatus.ON::equals).orElse(false))
+                .filter(tlDevice -> PrivateUtils.extractStringPrivate(tlDevice.getLN0(), COMPAS_LNODE_STATUS).map(status -> status.equals(ActiveStatus.ON.getValue())).orElse(false))
                 .map(tlDevice -> new LDeviceAdapter(iedAdapter, tlDevice));
     }
 
@@ -165,9 +165,7 @@ public class ExtRefEditorService implements ExtRefEditor {
                         && lnAdapter.getLNInst().equals(channel.getLNInst())
                         && trimToEmpty(channel.getLNPrefix()).equals(trimToEmpty(lnAdapter.getPrefix())))
                 .findFirst()
-                .filter(lnAdapter -> lnAdapter.getDaiModStValValue()
-                        .map(status -> status.equals(ActiveStatus.ON.getValue()))
-                        .orElse(true));
+                .filter(abstractLNAdapter -> PrivateUtils.extractStringPrivate(abstractLNAdapter.getCurrentElem(), COMPAS_LNODE_STATUS).map(status -> status.equals(ActiveStatus.ON.getValue())).orElse(true));
     }
 
     /**

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_dataTypeTemplateValid.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_dataTypeTemplateValid.xml
@@ -148,6 +148,7 @@
                 </LDevice>
                 <LDevice inst="LDTM1" ldName="IED_NAME1LDTM1">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -155,6 +156,7 @@
                         </DOI>
                     </LN0>
                     <LN lnClass="TVTR" inst="11" prefix="U01A" lnType="TVTR_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                     </LN>
                 </LDevice>
             </Server>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_extref_with_IedType_BCU.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_extref_with_IedType_BCU.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- SPDX-FileCopyrightText: 2023 2024 2025 RTE FRANCE -->
 <!-- -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
@@ -103,6 +103,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -112,15 +113,12 @@
                     <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
                     </LN>
                     <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
-                        <DOI name="Mod">
-                            <DAI name="stVal">
-                                <Val>off</Val>
-                            </DAI>
-                        </DOI>
+                        <Private type="COMPAS-LNodeStatus">off</Private>
                     </LN>
                 </LDevice>
                 <LDevice inst="LDPXINVALID" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">off</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>off</Val>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_iedSources_in_different_bay.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_iedSources_in_different_bay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- SPDX-FileCopyrightText: 2023 RTE FRANCE -->
+<!-- SPDX-FileCopyrightText: 2023 2024 2025 RTE FRANCE -->
 <!-- -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <SCL version="2007" revision="B" release="4" xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:compas="https://www.lfenergy.org/compas/extension/v1">
@@ -91,6 +91,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -99,13 +100,10 @@
                     </LN0>
                     <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
                         <!-- If not exist it considered active by default -->
-<!--                        <DOI name="Mod">-->
-<!--                            <DAI name="stVal">-->
-<!--                                <Val>on</Val>-->
-<!--                            </DAI>-->
-<!--                        </DOI>-->
+                        <!-- <Private type="COMPAS-LNodeStatus">on</Private>-->
                     </LN>
                     <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
+                        <Private type="COMPAS-LNodeStatus">off</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>off</Val>
@@ -115,6 +113,7 @@
                 </LDevice>
                 <LDevice inst="LDEVICE_INVALID" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">off</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>off</Val>
@@ -154,6 +153,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -162,11 +162,7 @@
                     </LN0>
                     <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
                         <!-- If not exist it considered active by default -->
-<!--                        <DOI name="Mod">-->
-<!--                            <DAI name="stVal">-->
-<!--                                <Val>on</Val>-->
-<!--                            </DAI>-->
-<!--                        </DOI>-->
+                        <!-- <Private type="COMPAS-LNodeStatus">on</Private> -->
                     </LN>
                 </LDevice>
             </Server>
@@ -199,20 +195,16 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME3LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
                             </DAI>
                         </DOI>
-
                     </LN0>
                     <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
                         <!-- If not exist it considered active by default -->
-<!--                        <DOI name="Mod">-->
-<!--                            <DAI name="stVal">-->
-<!--                                <Val>on</Val>-->
-<!--                            </DAI>-->
-<!--                        </DOI>-->
+                        <!-- <Private type="COMPAS-LNodeStatus">on</Private> -->
                     </LN>
                 </LDevice>
             </Server>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_manyIedSources_in_same_bay.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_manyIedSources_in_same_bay.xml
@@ -38,6 +38,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -124,6 +125,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -163,6 +165,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_processing_external_bind.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_processing_external_bind.xml
@@ -150,6 +150,7 @@
                 <Authentication/>
                 <LDevice inst="LDPX" ldName="IED_NAME2LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>

--- a/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_processing_internal_bind.xml
+++ b/sct-commons/src/test/resources/scd-ldepf/scd_ldepf_processing_internal_bind.xml
@@ -140,6 +140,7 @@
                 </LDevice>
                 <LDevice inst="LDPX" ldName="IED_NAME1LDPX">
                     <LN0 lnClass="LLN0" inst="" lnType="LLN0_ID1">
+                        <Private type="COMPAS-LNodeStatus">on</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>on</Val>
@@ -149,6 +150,7 @@
                     <LN lnClass="PTRC" inst="0" lnType="PTRC_ID1">
                     </LN>
                     <LN lnClass="PTRC" inst="2" lnType="PTRC_ID1">
+                        <Private type="COMPAS-LNodeStatus">off</Private>
                         <DOI name="Mod">
                             <DAI name="stVal">
                                 <Val>off</Val>


### PR DESCRIPTION
Closes #514 